### PR TITLE
Support json output format for summary

### DIFF
--- a/logs/common.go
+++ b/logs/common.go
@@ -219,6 +219,7 @@ type JsonLogsParser struct {
 	afterTime      string
 	include        LogMatcher
 	handler        EntryHandler
+	formatter 	   string
 }
 
 func (self *JsonLogsParser) addCommonArgs(cmd *cobra.Command) {
@@ -237,6 +238,7 @@ func (self *JsonLogsParser) addSummarizeArgs(cmd *cobra.Command) {
 	cmd.Flags().DurationVarP(&self.bucketSize, "interval", "n", time.Hour, "Interval for which to aggregate log messages")
 	cmd.Flags().IntVarP(&self.maxUnmatched, "max-unmatched", "u", 1, "Maximum unmatched log messages to output per bucket")
 	cmd.Flags().StringSliceVarP(&self.ignore, "ignore", "i", nil, "Filters to ignore")
+	cmd.Flags().StringVarP(&self.formatter, "output", "o", "text", "Specify output format: [text|json]")
 }
 
 func (self *JsonLogsParser) validate() error {

--- a/logs/controller_logs.go
+++ b/logs/controller_logs.go
@@ -20,6 +20,8 @@ import (
 	"github.com/spf13/cobra"
 )
 
+var OutputFormat = "text"
+
 func NewCtrlLogsCommand() *cobra.Command {
 	controllerLogs := &ControllerLogs{}
 	controllerLogs.Init()
@@ -46,6 +48,8 @@ func NewCtrlLogsCommand() *cobra.Command {
 		Aliases: []string{"s"},
 		RunE:    controllerLogs.summarize,
 	}
+
+	summarizeControllerLogsCmd.Flags().StringVarP(&OutputFormat, "output", "o", "text", "Specify output format: [text|json]")
 
 	controllerLogs.addSummarizeArgs(summarizeControllerLogsCmd)
 
@@ -512,6 +516,7 @@ func (self *ControllerLogs) summarize(cmd *cobra.Command, args []string) error {
 		bucketMatches:               map[LogFilter]int{},
 		maxUnmatchedLoggedPerBucket: self.maxUnmatched,
 		ignore:                      self.ignore,
+		formatter: 					 OutputFormat,
 	}
 
 	return ScanJsonLines(args[0], self.processLogEntry)

--- a/logs/controller_logs.go
+++ b/logs/controller_logs.go
@@ -20,7 +20,6 @@ import (
 	"github.com/spf13/cobra"
 )
 
-var OutputFormat = "text"
 
 func NewCtrlLogsCommand() *cobra.Command {
 	controllerLogs := &ControllerLogs{}
@@ -48,8 +47,6 @@ func NewCtrlLogsCommand() *cobra.Command {
 		Aliases: []string{"s"},
 		RunE:    controllerLogs.summarize,
 	}
-
-	summarizeControllerLogsCmd.Flags().StringVarP(&OutputFormat, "output", "o", "text", "Specify output format: [text|json]")
 
 	controllerLogs.addSummarizeArgs(summarizeControllerLogsCmd)
 
@@ -516,7 +513,7 @@ func (self *ControllerLogs) summarize(cmd *cobra.Command, args []string) error {
 		bucketMatches:               map[LogFilter]int{},
 		maxUnmatchedLoggedPerBucket: self.maxUnmatched,
 		ignore:                      self.ignore,
-		formatter: 					 OutputFormat,
+		formatter: 					  self.formatter,
 	}
 
 	return ScanJsonLines(args[0], self.processLogEntry)

--- a/logs/summary.go
+++ b/logs/summary.go
@@ -83,6 +83,7 @@ func (self *LogSummaryHandler) dumpBucket() {
 	} else {
 		self.dumpBucketText()
 	}
+
 }
 
 func (self *LogSummaryHandler) dumpBucketText() {
@@ -133,7 +134,7 @@ func (self *LogSummaryHandler) dumpBucketJson() {
 
 	j, err := json.Marshal(model)
 	if err != nil {
-
+		panic(err)
 	}
 
 	fmt.Printf("%s\n", string(j))

--- a/logs/summary.go
+++ b/logs/summary.go
@@ -17,6 +17,7 @@
 package logs
 
 import (
+	"encoding/json"
 	"fmt"
 	"github.com/openziti/foundation/util/stringz"
 	"github.com/pkg/errors"
@@ -31,6 +32,7 @@ type LogSummaryHandler struct {
 	unmatched                   int
 	maxUnmatchedLoggedPerBucket int
 	ignore                      []string
+	formatter 					string
 }
 
 func (self *LogSummaryHandler) HandleNewLine(ctx *JsonParseContext) error {
@@ -67,13 +69,23 @@ func (self *LogSummaryHandler) HandleUnmatched(ctx *JsonParseContext) error {
 	if ctx.entry != nil {
 		self.unmatched++
 		if self.unmatched <= self.maxUnmatchedLoggedPerBucket {
-			fmt.Printf("WARN: unmatched line: %v\n\n", ctx.line)
+			if self.formatter == "text" {
+				fmt.Printf("WARN: unmatched line: %v\n\n", ctx.line)
+			}
 		}
 	}
 	return nil
 }
 
 func (self *LogSummaryHandler) dumpBucket() {
+	if self.formatter == "json" {
+		self.dumpBucketJson()
+	} else {
+		self.dumpBucketText()
+	}
+}
+
+func (self *LogSummaryHandler) dumpBucketText() {
 	var filters []LogFilter
 	for k := range self.bucketMatches {
 		if !stringz.Contains(self.ignore, k.Id()) {
@@ -94,4 +106,36 @@ func (self *LogSummaryHandler) dumpBucket() {
 		fmt.Printf("    unmatched: %0000v\n", self.unmatched)
 	}
 	fmt.Println()
+}
+
+func (self *LogSummaryHandler) dumpBucketJson() {
+	var filters []LogFilter
+	for k := range self.bucketMatches {
+		if !stringz.Contains(self.ignore, k.Id()) {
+			filters = append(filters, k)
+		}
+	}
+	sort.Slice(filters, func(i, j int) bool {
+		return filters[i].Id() < filters[j].Id()
+	})
+	if len(filters) == 0 && self.unmatched == 0 {
+		return
+	}
+
+	model := make(map[string]interface{})
+	model["timestamp"] = self.currentBucket.Format(time.RFC3339)
+	for _, filter := range filters {
+		model[filter.Id()] = self.bucketMatches[filter]
+	}
+	if self.unmatched > 0 {
+		model["unmatched"] = fmt.Sprintf("    unmatched: %0000v\n", self.unmatched)
+	}
+
+	j, err := json.Marshal(model)
+	if err != nil {
+
+	}
+
+	fmt.Printf("%s\n", string(j))
+
 }


### PR DESCRIPTION
There might be a more preferred way to add a flag to the summarize sub-command, this was my first time working with cobra. Open to suggestions as to how that can be made cleaner. 

Default formatting remains exactly the same, no changes need to be made to the command. 

For json output, just add `--output json` to the summarize command. 
`./ziti-ops controller-logs summarize --output json ./ziti-controller.log`

which generates output like:
`{"CHANNEL_TLS_NOT_TLS":1,"IDLE_CIRCUIT_REQUEST":178,"LINK_FAILED":453,"LINK_FAULT":453,"LINK_REMOVED":459,"LINK_REROUTE":453,"LINK_REROUTE2":453,"TLS_NOT_TLS":1,"TLS_TIMOUT":2,"timestamp":"2022-01-26T19:00:00Z"}
`
